### PR TITLE
build release binary with Go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
 - '1.2'
 - '1.3'
 - '1.4'
+- '1.5'
 - 'tip'
 sudo: false
 before_deploy:
@@ -28,7 +29,7 @@ deploy:
     - build/go-prove_netbsd_amd64
     - build/go-prove_netbsd_arm
   on:
-    go: tip
+    go: '1.5'
     repo: shogo82148/go-prove
     tags: true
 


### PR DESCRIPTION
tip is a develop version.
so we should use stable version instead of tip.