### PR TITLE
標準エラーもパース対象にする

### DIFF
--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -92,7 +92,7 @@ func (f *JUnitFormatter) OpenTest(test *prove.Test) {
 			testCase.Failure = &JUnitFailure{
 				Message:  "not ok",
 				Type:     "",
-				Contents: line.Diagnostic,
+				Contents: line.FindOrigDiagnostic(),
 			}
 		}
 		ts.Tests++

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -58,7 +58,7 @@ type JUnitProperty struct {
 type JUnitFailure struct {
 	Message  string `xml:"message,attr"`
 	Type     string `xml:"type,attr"`
-	Contents string `xml:",chardata"`
+	Contents string `xml:",cdata"`
 }
 
 func (f *JUnitFormatter) formatDuration(d time.Duration) string {

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -82,7 +82,7 @@ func TestJUnit_failplan(t *testing.T) {
 	formatter := &JUnitFormatter{}
 	formatter.OpenTest(test)
 	b, _ := xml.MarshalIndent(formatter.Suites, "", "")
-	ok, err := regexp.Match(`<testsuites><testsuite tests="1" failures="0" errors="1" time="0.[0-9]+" name="[^"]*"><properties></properties><testcase classname="[^"]*" name="" time="0.[0-9]+"></testcase><testcase classname="[^"]*" name="Number of runned tests does not match plan." time="0.[0-9]+"><failure message="Some test were not executed, The test died prematurely." type="Plan">Bad plan</failure></testcase></testsuite></testsuites>`, b)
+	ok, err := regexp.Match(`<testsuites><testsuite tests="1" failures="0" errors="1" time="0.[0-9]+" name="[^"]*"><properties></properties><testcase classname="[^"]*" name="" time="0.[0-9]+"></testcase><testcase classname="[^"]*" name="Number of runned tests does not match plan." time="0.[0-9]+"><failure message="Some test were not executed, The test died prematurely." type="Plan"><!\[CDATA\[Bad plan\]\]></failure></testcase></testsuite></testsuites>`, b)
 	if err != nil {
 		t.Error(err)
 	}

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -90,3 +90,31 @@ func TestJUnit_failplan(t *testing.T) {
 		t.Errorf("incorrect output\n%s", string(b))
 	}
 }
+
+func TestJUnit_fail_with_diagnostic(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString(`print "not ok 1\n#   Failed test at -e line 1.\n1..1";`)
+
+	test := &prove.Test{
+		Path: f.Name(),
+		Env:  os.Environ(),
+		Exec: "perl",
+	}
+
+	test.Run()
+
+	formatter := &JUnitFormatter{}
+	formatter.OpenTest(test)
+	b, _ := xml.MarshalIndent(formatter.Suites, "", "")
+	ok, err := regexp.Match(`<testsuites><testsuite tests="1" failures="1" time="0.[0-9]+" name="[^"]*"><properties></properties><testcase classname="[^"]*" name="" time="0.[0-9]+"><failure message="not ok" type=""><!\[CDATA\[#   Failed test at -e line 1.
+\]\]></failure></testcase></testsuite></testsuites>`, b)
+	if err != nil {
+		t.Error(err)
+	}
+	if !ok {
+		t.Errorf("incorrect output\n%s", string(b))
+	}
+}


### PR DESCRIPTION
現状 go-prove は標準エラーをパースの対象にしていないので、diagnostic が空になっている
ので、jenkins の個別テスト結果見に行くと `not ok` だけ表示されてて辛いので標準エラーもパースに含めるようにしたい
