### PR TITLE
remove setting GOMAXPROCS

### DIFF
--- a/cli/go-prove/main.go
+++ b/cli/go-prove/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"runtime"
 
 	prove "github.com/shogo82148/go-prove"
 	formatter "github.com/shogo82148/go-prove/formatter"
@@ -10,9 +9,6 @@ import (
 )
 
 func main() {
-	cpus := runtime.NumCPU()
-	runtime.GOMAXPROCS(cpus)
-
 	p := prove.NewProve()
 	p.Formatter = &formatter.JUnitFormatter{}
 	p.ParseArgs(os.Args[1:])


### PR DESCRIPTION
The default value of GOMAXPROCS is  the number of cores available ( from Go1.5 https://golang.org/doc/go1.5 ).