### PR TITLE
fix invoke plugin.Run() wrpaper

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -34,7 +34,6 @@ func (w *Worker) run() {
 			w.prove.chanSuites <- test
 			log.Printf("finish %s", test.Path)
 		}
-		w.prove.wgWorkers.Done()
 	}
 
 	for _, p := range w.prove.Plugins {
@@ -46,4 +45,5 @@ func (w *Worker) run() {
 	}
 
 	f()
+	w.prove.wgWorkers.Done()
 }

--- a/worker.go
+++ b/worker.go
@@ -38,9 +38,11 @@ func (w *Worker) run() {
 	}
 
 	for _, p := range w.prove.Plugins {
-		f = func(g func()) func() {
-			return func() { p.Run(w, g) }
-		}(f)
+		pp := p
+		g := f
+		f = func() {
+			pp.Run(w, g)
+		}
 	}
 
 	f()

--- a/worker_test.go
+++ b/worker_test.go
@@ -30,7 +30,7 @@ func Test__run(t *testing.T) {
 		Exec: "perl",
 	}
 
-	pluginResChan = make(chan int, 5)
+	pluginResChan = make(chan int, 4)
 
 	p := NewProve()
 	w := NewWorker(p)
@@ -47,16 +47,11 @@ func Test__run(t *testing.T) {
 	}()
 	close(p.chanTests)
 	p.wgWorkers.Wait()
+	close(pluginResChan)
 
 	pluginRes := make([]int, 0, 4)
-OUTER:
-	for {
-		select {
-		case res := <-pluginResChan:
-			pluginRes = append(pluginRes, res)
-		default:
-			break OUTER
-		}
+	for res := range pluginResChan {
+		pluginRes = append(pluginRes, res)
 	}
 	if !reflect.DeepEqual(pluginRes, []int{2, 1, 1, 2}) {
 		t.Errorf(

--- a/worker_test.go
+++ b/worker_test.go
@@ -30,13 +30,7 @@ func Test__run(t *testing.T) {
 		Exec: "perl",
 	}
 
-	pluginResChan = make(chan int, 4)
-	pluginRes := make([]int, 0, 4)
-	go func() {
-		for res := range pluginResChan {
-			pluginRes = append(pluginRes, res)
-		}
-	}()
+	pluginResChan = make(chan int, 5)
 
 	p := NewProve()
 	w := NewWorker(p)
@@ -54,6 +48,16 @@ func Test__run(t *testing.T) {
 	close(p.chanTests)
 	p.wgWorkers.Wait()
 
+	pluginRes := make([]int, 0, 4)
+OUTER:
+	for {
+		select {
+		case res := <-pluginResChan:
+			pluginRes = append(pluginRes, res)
+		default:
+			break OUTER
+		}
+	}
 	if !reflect.DeepEqual(pluginRes, []int{2, 1, 1, 2}) {
 		t.Errorf(
 			"plugin exec is not valid: got: %v, expect: [2 1 1 2]",

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,0 +1,63 @@
+package prove
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+type testPlugin int
+
+var pluginResChan chan int
+
+func (p testPlugin) Run(w *Worker, f func()) {
+	pluginResChan <- int(p)
+	f()
+	pluginResChan <- int(p)
+}
+
+func Test__run(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString(`print "1..1\nok 1\n";`)
+
+	test := &Test{
+		Path: f.Name(),
+		Env:  os.Environ(),
+		Exec: "perl",
+	}
+
+	pluginResChan = make(chan int, 4)
+	pluginRes := make([]int, 0, 4)
+	go func() {
+		for res := range pluginResChan {
+			pluginRes = append(pluginRes, res)
+		}
+	}()
+
+	p := NewProve()
+	w := NewWorker(p)
+	p.Plugins = []Plugin{
+		testPlugin(1),
+		testPlugin(2),
+	}
+
+	w.Start()
+	p.chanTests <- test
+	go func() {
+		for range p.chanSuites {
+		}
+	}()
+	close(p.chanTests)
+	p.wgWorkers.Wait()
+
+	if !reflect.DeepEqual(pluginRes, []int{2, 1, 1, 2}) {
+		t.Errorf(
+			"plugin exec is not valid: got: %v, expect: [2 1 1 2]",
+			pluginRes,
+		)
+	}
+}


### PR DESCRIPTION
When `for _, p := range w.prove.Plugins {` then `p` is a used address in loops.
So closure function bind a `p` but `p` is only latest `p` in loops.