### PR TITLE
support specify formatter

### DIFF
--- a/cli/go-prove/main.go
+++ b/cli/go-prove/main.go
@@ -4,13 +4,11 @@ import (
 	"os"
 
 	prove "github.com/shogo82148/go-prove"
-	formatter "github.com/shogo82148/go-prove/formatter"
 	_ "github.com/shogo82148/go-prove/plugin"
 )
 
 func main() {
 	p := prove.NewProve()
-	p.Formatter = &formatter.JUnitFormatter{}
 	p.ParseArgs(os.Args[1:])
 	p.Run(nil)
 

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -1,4 +1,4 @@
-package Formatter
+package formatter
 
 import (
 	"encoding/xml"
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shogo82148/go-prove"
+	"github.com/shogo82148/go-prove/test"
 	tap "github.com/shogo82148/go-tap"
 )
 
@@ -80,7 +80,7 @@ func (f *JUnitFormatter) formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%.3f", d.Seconds())
 }
 
-func (f *JUnitFormatter) OpenTest(test *prove.Test) {
+func (f *JUnitFormatter) OpenTest(test *test.Test) {
 	className := strings.Replace(test.Path, "/", "_", -1)
 	className = strings.Replace(className, ".", "_", -1)
 

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -1,4 +1,4 @@
-package Formatter
+package formatter
 
 import (
 	"encoding/xml"
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/shogo82148/go-prove"
+	"github.com/shogo82148/go-prove/test"
 )
 
 func TestJUnit_success(t *testing.T) {
@@ -17,7 +17,7 @@ func TestJUnit_success(t *testing.T) {
 	}
 	f.WriteString(`print "1..1\nok 1\n";`)
 
-	test := &prove.Test{
+	test := &test.Test{
 		Path: f.Name(),
 		Env:  os.Environ(),
 		Exec: "perl",
@@ -25,9 +25,9 @@ func TestJUnit_success(t *testing.T) {
 
 	test.Run()
 
-	formatter := &JUnitFormatter{}
-	formatter.OpenTest(test)
-	b, _ := xml.MarshalIndent(formatter.Suites, "", "")
+	fmtter := &JUnitFormatter{}
+	fmtter.OpenTest(test)
+	b, _ := xml.MarshalIndent(fmtter.Suites, "", "")
 	re := `^<testsuites><testsuite tests="1" failures="0" errors="0" skipped="0" time="0.[0-9]+" name="[^"]+">` +
 		`<properties></properties><testcase classname="[^"]+" name="" time="0.[0-9]+">` +
 		`<system-out><!\[CDATA\[ok 1` + "\n" +
@@ -48,7 +48,7 @@ func TestJUnit_fail(t *testing.T) {
 	}
 	f.WriteString(`print "1..1\nnot ok 1\n";`)
 
-	test := &prove.Test{
+	test := &test.Test{
 		Path: f.Name(),
 		Env:  os.Environ(),
 		Exec: "perl",
@@ -56,9 +56,9 @@ func TestJUnit_fail(t *testing.T) {
 
 	test.Run()
 
-	formatter := &JUnitFormatter{}
-	formatter.OpenTest(test)
-	b, _ := xml.MarshalIndent(formatter.Suites, "", "")
+	fmtter := &JUnitFormatter{}
+	fmtter.OpenTest(test)
+	b, _ := xml.MarshalIndent(fmtter.Suites, "", "")
 	re := `^<testsuites><testsuite tests="1" failures="1" errors="0" skipped="0" time="0.[0-9]+" name="[^"]+">` +
 		`<properties></properties><testcase classname="[^"]+" name="" time="0.[0-9]+">` +
 		`<failure message="not ok 1" type="TestFailed"></failure>` +
@@ -80,7 +80,7 @@ func TestJUnit_failplan(t *testing.T) {
 	}
 	f.WriteString(`print "1..2\nok 1\n";`)
 
-	test := &prove.Test{
+	test := &test.Test{
 		Path: f.Name(),
 		Env:  os.Environ(),
 		Exec: "perl",
@@ -88,9 +88,9 @@ func TestJUnit_failplan(t *testing.T) {
 
 	test.Run()
 
-	formatter := &JUnitFormatter{}
-	formatter.OpenTest(test)
-	b, _ := xml.MarshalIndent(formatter.Suites, "", "")
+	fmtter := &JUnitFormatter{}
+	fmtter.OpenTest(test)
+	b, _ := xml.MarshalIndent(fmtter.Suites, "", "")
 	re := `^<testsuites><testsuite tests="1" failures="0" errors="1" skipped="0" time="0.[0-9]+" name="[^"]+">` +
 		`<properties></properties>` +
 		`<testcase classname="[^"]+" name="" time="0.[0-9]+"><system-out><!\[CDATA\[ok 1` + "\n" + `\]\]></system-out></testcase>` // +

--- a/formatter/tap.go
+++ b/formatter/tap.go
@@ -1,0 +1,24 @@
+package formatter
+
+import (
+	"fmt"
+
+	"github.com/shogo82148/go-prove/test"
+	tap "github.com/shogo82148/go-tap"
+)
+
+type TapFormatter struct {
+	Suites []*tap.Testsuite
+}
+
+func (f *TapFormatter) OpenTest(test *test.Test) {
+	f.Suites = append(f.Suites, test.Suite)
+}
+
+func (f *TapFormatter) Report() {
+	for _, s := range f.Suites {
+		for _, t := range s.Tests {
+			fmt.Printf("%#v", t)
+		}
+	}
+}

--- a/prove.go
+++ b/prove.go
@@ -142,7 +142,7 @@ func (p *Prove) Run(args []string) {
 	switch p.formatter {
 	case "junit":
 		p.Formatter = &formatter.JUnitFormatter{}
-	case "prove":
+	case "tap":
 		fallthrough
 	case "":
 		p.Formatter = &formatter.TapFormatter{}

--- a/test/test.go
+++ b/test/test.go
@@ -1,4 +1,4 @@
-package prove
+package test
 
 import (
 	"fmt"

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,4 +1,4 @@
-package prove
+package test
 
 import (
 	"io/ioutil"

--- a/worker_test.go
+++ b/worker_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/shogo82148/go-prove/test"
 )
 
 type testPlugin int
@@ -24,7 +26,7 @@ func Test__run(t *testing.T) {
 	}
 	f.WriteString(`print "1..1\nok 1\n";`)
 
-	test := &Test{
+	test := &test.Test{
 		Path: f.Name(),
 		Env:  os.Environ(),
 		Exec: "perl",


### PR DESCRIPTION
go-tap がパース結果を tap 形式で出力出来るようになってるようなのでフォーマッタ指定出来るとよさそうでは？と思ってPRにしてみました

-----

```
$ go run cli/go-prove/main.go -formatter junit
2017/10/08 11:25:17 start t/01.t
2017/10/08 11:25:17 finish t/01.t
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
    <testsuite tests="3" failures="0" errors="0" skipped="0" time="0.100" name="t_01_t">
        <properties></properties>
        <testcase classname="t_01_t" name="foo" time="0.098">
            <system-out><![CDATA[ok 1 - foo
]]></system-out>
        </testcase>
        <testcase classname="t_01_t" name="bar" time="0.000">
            <system-out><![CDATA[    # Subtest: bar
        # Subtest: subtest1
        ok 1 - subsubtest1
        ok 2 - subsubtest2 # TODO not implemented yet
        # note message for subtests2
        ok 3 - subsubtest3
        1..3
    ok 1 - subtest1
    1..1
ok 2 - bar
]]></system-out>
        </testcase>
        <testcase classname="t_01_t" name="foobar" time="0.000">
            <system-out><![CDATA[ok 3 - foobar
]]></system-out>
        </testcase>
    </testsuite>
</testsuites>
```
```
$ go run cli/go-prove/main.go -formatter tap
2017/10/08 11:25:23 start t/01.t
2017/10/08 11:25:23 finish t/01.t
ok 1 - foo
    # Subtest: bar
        # Subtest: subtest1
        ok 1 - subsubtest1
        ok 2 - subsubtest2 # TODO not implemented yet
        # note message for subtests2
        ok 3 - subsubtest3
        1..3
    ok 1 - subtest1
    1..1
ok 2 - bar
ok 3 - foobar
```
```
$ go run cli/go-prove/main.go
2017/10/08 11:25:31 start t/01.t
2017/10/08 11:25:31 finish t/01.t
ok 1 - foo
    # Subtest: bar
        # Subtest: subtest1
        ok 1 - subsubtest1
        ok 2 - subsubtest2 # TODO not implemented yet
        # note message for subtests2
        ok 3 - subsubtest3
        1..3
    ok 1 - subtest1
    1..1
ok 2 - bar
ok 3 - foobar
```
```
$ go run cli/go-prove/main.go -formatter hoge
panic: unknown formatter: hoge

goroutine 1 [running]:
github.com/shogo82148/go-prove.(*Prove).Run(0xc4200b2000, 0x0, 0x0, 0x0)
	/Users/seto-wataru/workspace/go/eupho/src/github.com/shogo82148/go-prove/prove.go:150 +0x590
main.main()
	/Users/seto-wataru/workspace/go/eupho/src/github.com/shogo82148/go-prove/cli/go-prove/main.go:13 +0xa0
exit status 2
```