### PR TITLE
specify "./" on cmdArgs to support perl 5.26

### DIFF
--- a/plugin/harriet.go
+++ b/plugin/harriet.go
@@ -25,7 +25,7 @@ func init() {
 
 func harrietLoader(name, args string) prove.Plugin {
 	cmd := "harriet"
-	cmdArgs := []string{"t/harriet"}
+	cmdArgs := []string{"./t/harriet"}
 
 	a, _ := shellwords.Parse(args)
 	if len(a) > 0 {


### PR DESCRIPTION
Hello! We try to use go-prove on perl 5.26, but I've got error around `@INC` spec. change from perl 5.26.

I fix it.