### PR TITLE
bump Go 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.18"
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,12 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        go:
-          - "1.18"
 
     steps:
-      - name: Set up Go ${{ matrix.go }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -38,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.18"
+          go-version-file: go.mod
       - name: Check GoReleaser configure
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
           - windows-latest
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
 
       - name: Test
         run: make test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/go-prove
 
-go 1.18
+go 1.22.2
 
 require (
 	github.com/lestrrat-go/test-mysqld v0.0.0-20190527004737-6c91be710371


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub workflows to dynamically determine the Go version from the `go.mod` file, enhancing automation and consistency in testing and release processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->