### PR TITLE
fix deprecated goreleaser flags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,8 +32,4 @@ archives:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  use: github-native

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 
 .PHONY: snapshot
 snapshot:
-	goreleaser --snapshot --skip-publish --rm-dist
+	goreleaser --snapshot --skip=publish --clean
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
  • DEPRECATED: --skip-publish was deprecated in favor of --skip=publish, check https://goreleaser.com/deprecations#-skip for more details
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated the release process to enhance the cleanliness of distributions and refined the snapshot publishing behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->