### PR TITLE
Fix goreleaser warnings 2025 09 15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,6 @@ archives:
       - goos: windows
         format: zip
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   use: github-native

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ archives:
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 snapshot:
   version_template: "{{ .Tag }}-next"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
 checksum:
   name_template: "checksums.txt"
 archives:
-  - builds:
+  - ids:
       - "cli"
     files:
       - CREDITS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Pinned release tooling to GoReleaser v2 for more predictable builds.
  - Updated packaging configuration to the latest schema (ids, formats, version template).
  - Windows artifacts continue to ship as .zip; snapshot naming updated but remains compatible.
  - These changes affect only the build/release process; no user-facing functionality is altered and no action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->